### PR TITLE
Add documentation for onboarding daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # Devcade-onboard
 The onboard menu and control software for the Devcade custom arcade system.
+
+
+## The Idiot
+
+### Prereqs
+
+Debian >=10
+
+A user named `devcade`
+
+`apt install xorg` and friends (I dont actually know what all is installed)
+
+### Daemon
+
+_daemons are always watching. They are always with you. So is Willard._
+
+The Devcade Idiot is running Debian 10 with a very _very_ simple Xorg server setup. It has a systemd service configured to launch the onboarding program, along with said xorg server, as the `devcade` user.
+
+You can find everything(tm) you need to set up the Devcade Idiot in `/idiot`. This includes the systemd service, which contains the path you need to install it at.
+
+```
+/etc/systemd/system/devcade-onboard.service
+```
+
+This should be interactable as a normal systemd service, so `enable`/`disable` it as normal.

--- a/idiot/devcade-onboard.service
+++ b/idiot/devcade-onboard.service
@@ -1,0 +1,21 @@
+#  /etc/systemd/system/devcade-onboard.service
+[Unit]
+Description=CSH Devcade Onboarding Service
+Documentation=haha youre funny
+After=network.target auditd.service
+
+[Service]
+User=devcade
+Group=devcade
+ExecStart=startx /home/devcade/test/publish/onboard
+
+ExecReload=startx /home/devcade/test/publish/onboard
+ExecReload=/bin/kill -9 -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartPreventExitStatus=255
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+Alias=devcade-onboard.service

--- a/onboard/onboard.sln
+++ b/onboard/onboard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32106.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "onboard", "onboard.csproj", "{3D323CAC-2E98-42FB-BA86-67D111FBBB18}"
 EndProject


### PR DESCRIPTION
I got the systemd service set up(tm) and it no longer crashes and runs as the correct user. Hopefully this will work for long enough to demo it :)