### PR TITLE
Fix Unzip Failure Due to Already Existing

### DIFF
--- a/onboard/DevcadeClient.cs
+++ b/onboard/DevcadeClient.cs
@@ -131,6 +131,9 @@ namespace onboard
             string path = $"/tmp/{gameName}.zip";
             try {
                 Console.WriteLine($"Extracting {path}");
+                if (Directory.Exists($"/tmp/{gameName}")) {
+                    Directory.Delete($"/tmp/{gameName}", true);
+                }
                 Directory.CreateDirectory($"/tmp/{gameName}");
                 ZipFile.ExtractToDirectory(path, $"/tmp/{gameName}");
             } catch (Exception e) {


### PR DESCRIPTION
**I am not a C# Developer**

@esoccoli ran into an issue with @ethanf108 's weird clock. The boot would fail because it would try to unzip and couldn't because it already exists.